### PR TITLE
Upgrading project to support Java 21 or higher.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,11 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<vavr.version>0.9.2</vavr.version>
-		<junit.version>4.12</junit.version>
-		<assertj.version>3.9.1</assertj.version>
+		<vavr.version>0.10.4</vavr.version>
+		<junit.version>5.11.3</junit.version>
+		<assertj.version>3.26.3</assertj.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
 
 	<issueManagement>
@@ -29,7 +30,7 @@
 	<parent>
 		<groupId>org.modelmapper</groupId>
 		<artifactId>modelmapper-parent</artifactId>
-		<version>2.1.0</version>
+		<version>3.2.1</version>
 	</parent>
 
 	<scm>
@@ -50,6 +51,18 @@
 		</repository>
 	</distributionManagement>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -67,17 +80,16 @@
 			<artifactId>vavr</artifactId>
 			<version>${vavr.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-			<version>${junit.version}</version>
-		</dependency>
-		<dependency>
+    <dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<scope>compile</scope>
-			<version>1.18.0</version>
+			<version>1.18.36</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -86,23 +98,19 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
+				<version>3.13.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.apache.maven.surefire</groupId>
-						<artifactId>surefire-junit4</artifactId>
-						<version>2.21.0</version>
-					</dependency>
-				</dependencies>
+				<version>3.5.2</version>
+<!--				<dependencies>-->
+<!--					<dependency>-->
+<!--						<groupId>org.apache.maven.surefire</groupId>-->
+<!--						<artifactId>surefire-junit4</artifactId>-->
+<!--						<version>2.21.0</version>-->
+<!--					</dependency>-->
+<!--				</dependencies>-->
 			</plugin>
 		</plugins>
 	</build>
@@ -133,14 +141,14 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-surefire-plugin</artifactId>
-						<version>2.21.0</version>
-						<dependencies>
-							<dependency>
-								<groupId>org.apache.maven.surefire</groupId>
-								<artifactId>surefire-junit4</artifactId>
-								<version>2.21.0</version>
-							</dependency>
-						</dependencies>
+						<version>3.5.2</version>
+<!--						<dependencies>-->
+<!--							<dependency>-->
+<!--								<groupId>org.apache.maven.surefire</groupId>-->
+<!--								<artifactId>surefire-junit4</artifactId>-->
+<!--								<version>2.21.0</version>-->
+<!--							</dependency>-->
+<!--						</dependencies>-->
 					</plugin>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/github/julianps/modelmapper/ValueConverterTest.java
+++ b/src/test/java/com/github/julianps/modelmapper/ValueConverterTest.java
@@ -1,10 +1,9 @@
 package com.github.julianps.modelmapper;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.convention.MatchingStrategies;
 
@@ -14,7 +13,7 @@ public class ValueConverterTest {
 
 	private ModelMapper modelMapper;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		modelMapper = new ModelMapper();
 		modelMapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
@@ -69,7 +68,7 @@ public class ValueConverterTest {
 		assertThat(destList.list.get(1))
 				.isNotNull()
 				.isInstanceOf(StubFactory.Dest.class);
-		assertTrue(destList.list.get(1).x == 5);
+		assertThat(destList.list.get(1).x).isEqualTo(5);
 	}
 
 
@@ -89,7 +88,7 @@ public class ValueConverterTest {
 		assertThat(destArray.array.get(1))
 				.isNotNull()
 				.isInstanceOf(StubFactory.Dest.class);
-		assertTrue(destArray.array.get(1).x == 5);
+		assertThat(destArray.array.get(1).x).isEqualTo(5);
 	}
 
 	@Test
@@ -108,6 +107,6 @@ public class ValueConverterTest {
 		assertThat(destSet.set.head())
 				.isNotNull()
 				.isInstanceOf(StubFactory.Dest.class);
-		assertTrue(destSet.set.head().x == 5);
+		assertThat(destSet.set.head().x).isEqualTo(5);
 	}
 }


### PR DESCRIPTION
Please consider this PR to upgrade the project to Java 21 and updated versions of Vavr and ModelMapper
and release a new version with these changes.

- Build for Java 21
- Upgraded Lombok to latest version to support latest java versions. 
- Replaced JUnit4 with JUnit5.
- Updated Vavr to 0.10.4.
- Updated to latest ModelMapper 3.2.1 to support latest java versions.